### PR TITLE
Release 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -26,6 +26,21 @@ const INFO_ROWS = [
 
 const CHANGELOG = [
   {
+    version: '3.0.4',
+    date: '2026-03-21',
+    changes: [
+      'Search modal and help dialog backgrounds are now fully opaque',
+      'Recent activity on the Dashboard now shows all apps updated in the past 48 hours instead of the top 10',
+      'Dashboard stat cards are distributed evenly across the full page width',
+      'Fixed stale closure in global search keyboard handler that could prevent search history from saving correctly',
+      'Fixed uncleaned timeouts in the version details copy-to-clipboard functions that could update state after unmount',
+      'Fixed tab focus escaping the global search modal when no results are shown',
+      'Fixed clickable list items in Dashboard being inaccessible to keyboard and screen reader users',
+      'Fixed unstable row keys and index-based copy state in the version table that caused visual state to appear on the wrong row after sorting',
+      'Replaced render-time state mutation with useEffect for resetting filters when switching apps',
+    ],
+  },
+  {
     version: '3.0.3',
     date: '2026-03-18',
     changes: [

--- a/src/components/AppDetails.tsx
+++ b/src/components/AppDetails.tsx
@@ -98,6 +98,18 @@ function saveHiddenColumns(name: string, hidden: Set<string>) {
   } catch { /* ignore */ }
 }
 
+function initArchitectures(name: string, archs: string[]): Set<string> {
+  const saved = loadSavedFilters(name);
+  if (saved) return new Set(archs.filter((a) => saved.archs.has(a)));
+  return new Set(archs);
+}
+
+function initFileTypes(name: string, types: string[]): Set<string> {
+  const saved = loadSavedFilters(name);
+  if (saved) return new Set(types.filter((t) => saved.types.has(t)));
+  return new Set(types);
+}
+
 export default function AppDetails({ appName, displayName, versions, lastUpdated, onBack, base }: AppDetailsProps) {
   const feedUrl = `${base}feeds/${appName}.xml`;
   // Derive unique filter values from data
@@ -115,18 +127,6 @@ export default function AppDetails({ appName, displayName, versions, lastUpdated
     return Array.from(set).sort();
   }, [versions]);
 
-  function initArchitectures(name: string, archs: string[]): Set<string> {
-    const saved = loadSavedFilters(name);
-    if (saved) return new Set(archs.filter((a) => saved.archs.has(a)));
-    return new Set(archs);
-  }
-
-  function initFileTypes(name: string, types: string[]): Set<string> {
-    const saved = loadSavedFilters(name);
-    if (saved) return new Set(types.filter((t) => saved.types.has(t)));
-    return new Set(types);
-  }
-
   const [selectedArchitectures, setSelectedArchitectures] = useState<Set<string>>(
     () => initArchitectures(appName, architectures)
   );
@@ -135,14 +135,12 @@ export default function AppDetails({ appName, displayName, versions, lastUpdated
   );
 
   // Reset filters when app changes
-  const [lastApp, setLastApp] = useState(appName);
-  if (lastApp !== appName) {
-    setLastApp(appName);
+  useEffect(() => {
     setSelectedArchitectures(initArchitectures(appName, architectures));
     setSelectedFileTypes(initFileTypes(appName, fileTypes));
     setHiddenColumns(loadHiddenColumns(appName));
     setColumnSearch({});
-  }
+  }, [appName, architectures, fileTypes]);
 
   const filteredVersions = useMemo(() => {
     return versions.filter((v) => {
@@ -230,15 +228,21 @@ export default function AppDetails({ appName, displayName, versions, lastUpdated
   const [sortCol, setSortCol] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [columnSearch, setColumnSearch] = useState<Record<string, string>>({});
-  const [copiedRow, setCopiedRow] = useState<number | null>(null);
+  const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const [copiedCmd, setCopiedCmd] = useState(false);
   const [copyError, setCopyError] = useState(false);
 
-  // Reset column search when app changes
-  if (lastApp !== appName) {
-    // (lastApp/appName sync already handled above)
-    // columnSearch reset handled via the key approach below
-  }
+  const copyErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copiedCmdTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copiedRowTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyErrorTimer.current) clearTimeout(copyErrorTimer.current);
+      if (copiedCmdTimer.current) clearTimeout(copiedCmdTimer.current);
+      if (copiedRowTimer.current) clearTimeout(copiedRowTimer.current);
+    };
+  }, []);
 
   function handleSort(col: string) {
     if (sortCol === col) {
@@ -288,21 +292,24 @@ export default function AppDetails({ appName, displayName, versions, lastUpdated
 
   function showCopyError() {
     setCopyError(true);
-    setTimeout(() => setCopyError(false), 2500);
+    if (copyErrorTimer.current) clearTimeout(copyErrorTimer.current);
+    copyErrorTimer.current = setTimeout(() => setCopyError(false), 2500);
   }
 
   function copyEvergreenCommand() {
     const cmd = `Get-EvergreenApp -Name ${appName}`;
     navigator.clipboard.writeText(cmd).then(() => {
       setCopiedCmd(true);
-      setTimeout(() => setCopiedCmd(false), 1500);
+      if (copiedCmdTimer.current) clearTimeout(copiedCmdTimer.current);
+      copiedCmdTimer.current = setTimeout(() => setCopiedCmd(false), 1500);
     }).catch(showCopyError);
   }
 
-  function copyRowUri(uri: string, rowIndex: number) {
+  function copyRowUri(uri: string, rowKey: string) {
     navigator.clipboard.writeText(uri).then(() => {
-      setCopiedRow(rowIndex);
-      setTimeout(() => setCopiedRow(null), 1500);
+      setCopiedRow(rowKey);
+      if (copiedRowTimer.current) clearTimeout(copiedRowTimer.current);
+      copiedRowTimer.current = setTimeout(() => setCopiedRow(null), 1500);
     }).catch(showCopyError);
   }
 
@@ -489,15 +496,16 @@ export default function AppDetails({ appName, displayName, versions, lastUpdated
                   const rowUri = columns
                     .map((col) => v[col])
                     .find((val): val is string => typeof val === 'string' && /^https?:\/\//i.test(val));
-                  const isCopied = copiedRow === i;
+                  const trKey = [v.Version, v.Architecture, v.URI ?? '', v.Type ?? '', v.Language ?? ''].join('|') || String(i);
+                  const isCopied = copiedRow === rowUri;
                   return (
                     <tr
-                      key={i}
+                      key={trKey}
                       className={[
                         rowUri ? 'version-table__row--has-uri' : '',
                         isCopied ? 'version-table__row--copied' : '',
                       ].filter(Boolean).join(' ')}
-                      onClick={rowUri ? () => copyRowUri(rowUri, i) : undefined}
+                      onClick={rowUri ? () => copyRowUri(rowUri, rowUri) : undefined}
                       title={rowUri ? (isCopied ? 'Copied!' : 'Click to copy URI') : undefined}
                     >
                       {visibleColumns.map((col) => {

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -188,7 +188,14 @@ function UriLookup({ apps, onSelectApp }: { apps: AppEntry[]; onSelectApp: (name
             const v = m.version;
             const meta = [v.Version, v.Architecture, v.Type ?? getFileType(v)].filter(Boolean).join(' · ');
             return (
-              <li key={i} className="uri-lookup__result" onClick={() => onSelectApp(m.appName)}>
+              <li
+                key={`${m.appName}|${m.matchedUri}`}
+                className="uri-lookup__result"
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectApp(m.appName)}
+                onKeyDown={(e) => e.key === 'Enter' && onSelectApp(m.appName)}
+              >
                 <div className="uri-lookup__result-app">
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                     <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.5" />
@@ -234,10 +241,10 @@ interface RecentActivityProps {
 
 const RecentActivity = memo(function RecentActivity({ apps, onSelectApp }: RecentActivityProps) {
   const recent = useMemo(() => {
+    const cutoff = Date.now() - 48 * 3600 * 1000;
     return apps
-      .filter((a) => a.lastUpdated !== null)
-      .sort((a, b) => new Date(b.lastUpdated!).getTime() - new Date(a.lastUpdated!).getTime())
-      .slice(0, 10);
+      .filter((a) => a.lastUpdated !== null && new Date(a.lastUpdated).getTime() >= cutoff)
+      .sort((a, b) => new Date(b.lastUpdated!).getTime() - new Date(a.lastUpdated!).getTime());
   }, [apps]);
 
   if (recent.length === 0) return null;
@@ -245,10 +252,17 @@ const RecentActivity = memo(function RecentActivity({ apps, onSelectApp }: Recen
   return (
     <div className="dashboard-card recent-activity">
       <h2 className="dashboard-card__title">Recent activity</h2>
-      <p className="dashboard-card__subtitle">Apps with the most recent data updates</p>
+      <p className="dashboard-card__subtitle">Apps updated in the past 48 hours ({recent.length})</p>
       <ul className="recent-activity__list">
         {recent.map((app) => (
-          <li key={app.name} className="recent-activity__item" onClick={() => onSelectApp(app.name)}>
+          <li
+            key={app.name}
+            className="recent-activity__item"
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelectApp(app.name)}
+            onKeyDown={(e) => e.key === 'Enter' && onSelectApp(app.name)}
+          >
             <span className="recent-activity__name">{app.displayName}</span>
             <span className="recent-activity__date">{formatRelativeDate(app.lastUpdated!)}</span>
           </li>

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -161,7 +161,7 @@ export default function GlobalSearch({ apps, onSelect }: GlobalSearchProps) {
     [results]
   );
 
-  function handleSelect(appName: string) {
+  const handleSelect = useCallback((appName: string) => {
     const q = inputValue.trim();
     if (q) {
       const next = [q, ...searchHistory.filter((h) => h !== q)].slice(0, MAX_HISTORY);
@@ -170,7 +170,7 @@ export default function GlobalSearch({ apps, onSelect }: GlobalSearchProps) {
     }
     setOpen(false);
     onSelect(appName);
-  }
+  }, [inputValue, searchHistory, onSelect]);
 
   function applyHistoryQuery(q: string) {
     setInputValue(q);
@@ -198,7 +198,7 @@ export default function GlobalSearch({ apps, onSelect }: GlobalSearchProps) {
         setOpen(false);
       }
     },
-    [flatItems, activeIndex]
+    [flatItems, activeIndex, handleSelect]
   );
 
   // Scroll active item into view
@@ -247,7 +247,7 @@ export default function GlobalSearch({ apps, onSelect }: GlobalSearchProps) {
   function handleOverlayKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     if (e.key !== 'Tab' || !modalRef.current) return;
     const focusable = Array.from(modalRef.current.querySelectorAll<HTMLElement>(FOCUSABLE));
-    if (focusable.length === 0) return;
+    if (focusable.length === 0) { e.preventDefault(); return; }
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
     if (e.shiftKey) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1080,9 +1080,7 @@ body.search-open #root {
 .global-search-modal {
   width: 100%;
   max-width: 580px;
-  background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--panel-bg);
   border: 1px solid var(--panel-border);
   border-radius: 10px;
   box-shadow: 0 20px 60px rgba(0,0,0,0.3);
@@ -1307,13 +1305,7 @@ body.search-open #root {
   color: var(--accent);
 }
 
-[data-theme="dark"] .global-search-modal {
-  background: rgba(28, 40, 38, 0.75);
-}
 
-[data-theme="dark"] .shortcuts-modal {
-  background: rgba(28, 40, 38, 0.75);
-}
 
 /* Show more button */
 .global-search-show-more {
@@ -1379,10 +1371,10 @@ body.search-open #root {
   gap: 20px;
 }
 
-/* Stat cards row — 6 equal columns, same gap as .dashboard-charts */
+/* Stat cards row — equal columns filling full width, same gap as .dashboard-charts */
 .dashboard-stats {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -1939,9 +1931,7 @@ body.search-open #root {
 .shortcuts-modal {
   width: 100%;
   max-width: 420px;
-  background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--panel-bg);
   border: 1px solid var(--panel-border);
   border-radius: 10px;
   box-shadow: 0 20px 60px rgba(0,0,0,0.3);


### PR DESCRIPTION
## Changes

- **Version bump** to 3.0.4
- **Search modal & help dialog** now use fully opaque backgrounds instead of translucent blur effects
- **Recent activity** on Dashboard now shows all apps updated in the past 48 hours instead of top 10
- **Dashboard stat cards** use flexible grid layout to distribute evenly across full page width
- **Fixed stale closure** in global search keyboard handler preventing search history from saving
- **Fixed memory leaks** by cleaning up setTimeout timers in copy-to-clipboard functions to prevent state updates after unmount
- **Fixed tab focus** escaping global search modal when no results are shown
- **Fixed accessibility** of clickable list items in Dashboard (added keyboard handlers and ARIA roles)
- **Fixed version table state** by using stable row keys instead of indices, preventing visual state from appearing on wrong row after sorting
- **Refactored filter reset logic** from render-time mutation to useEffect when switching apps
- **Updated changelog** with v3.0.4 release notes